### PR TITLE
changed from using map to red-black tree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vitezslav-lindovsky/nsec3walker
 go 1.23.2
 
 require (
+	github.com/emirpasic/gods v1.18.1
 	github.com/miekg/dns v1.1.62
 	github.com/spf13/cobra v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
+github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=


### PR DESCRIPTION
isHashInRange is now more robust due to the tree we can more accurately tell if a hash is in an existing range without requiring it's prefix to match the range start hash prefix.

fixed race condition for values of cntChainsEmpty and cntChains in Add() but this mutex may have a negative performance impact

added a check to exit early if all hashes are found based on the hash ranges being sequential and complete